### PR TITLE
Merge latest developments from Alex's repo to new base

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -712,7 +712,7 @@ module.exports = grammar({
     value_argument_label: ($) =>
       prec.left(
         choice($.simple_identifier, alias("async", $.simple_identifier))
-      ), 
+      ),
     value_argument: ($) =>
       prec.left(
         seq(
@@ -722,15 +722,7 @@ module.exports = grammar({
               seq(field("reference_specifier", $.simple_identifier), ":")
             ),
             seq(
-              optional(
-                seq(
-                  field(
-                    "name",
-                    $.value_argument_label
-                  ),
-                  ":"
-                )
-              ),
+              optional(seq(field("name", $.value_argument_label), ":")),
               field("value", $._expression)
             )
           )

--- a/grammar.js
+++ b/grammar.js
@@ -709,6 +709,10 @@ module.exports = grammar({
           seq("[", optional(sep1($.value_argument, ",")), "]")
         )
       ),
+    value_argument_label: ($) => prec.left(choice(
+        $.simple_identifier,
+        alias("async", $.simple_identifier)
+    )), 
     value_argument: ($) =>
       prec.left(
         seq(
@@ -722,10 +726,7 @@ module.exports = grammar({
                 seq(
                   field(
                     "name",
-                    choice(
-                      $.simple_identifier,
-                      alias("async", $.simple_identifier)
-                    )
+                    $.value_argument_label
                   ),
                   ":"
                 )

--- a/grammar.js
+++ b/grammar.js
@@ -719,7 +719,7 @@ module.exports = grammar({
           optional($.type_modifiers),
           choice(
             repeat1(
-              seq(field("reference_specifier", $.simple_identifier), ":")
+              seq(field("reference_specifier", $.value_argument_label), ":")
             ),
             seq(
               optional(seq(field("name", $.value_argument_label), ":")),

--- a/grammar.js
+++ b/grammar.js
@@ -709,10 +709,11 @@ module.exports = grammar({
           seq("[", optional(sep1($.value_argument, ",")), "]")
         )
       ),
-    value_argument_label: ($) => prec.left(choice(
+    value_argument_label: ($) => 
+      prec.left(choice(
         $.simple_identifier,
         alias("async", $.simple_identifier)
-    )), 
+      )), 
     value_argument: ($) =>
       prec.left(
         seq(

--- a/grammar.js
+++ b/grammar.js
@@ -709,11 +709,10 @@ module.exports = grammar({
           seq("[", optional(sep1($.value_argument, ",")), "]")
         )
       ),
-    value_argument_label: ($) => 
-      prec.left(choice(
-        $.simple_identifier,
-        alias("async", $.simple_identifier)
-      )), 
+    value_argument_label: ($) =>
+      prec.left(
+        choice($.simple_identifier, alias("async", $.simple_identifier))
+      ), 
     value_argument: ($) =>
       prec.left(
         seq(

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -1254,7 +1254,8 @@ let result: HasGeneric<P1 & P2> = HasGeneric<P1 & P2>(t: "Hello")
       (constructor_suffix
         (value_arguments
           (value_argument
-            (simple_identifier)
+            (value_argument_label
+              (simple_identifier))
             (line_string_literal
               (line_str_text))))))))
 

--- a/test/corpus/emojis.txt
+++ b/test/corpus/emojis.txt
@@ -68,10 +68,12 @@ func 👨‍❤️‍💋‍👨(🙋🏼‍♂️ 🙋‍♂️: Man, 🙋🏻�
     (call_suffix
       (value_arguments
         (value_argument
-          (simple_identifier)
+          (value_argument_label
+            (simple_identifier))
           (simple_identifier))
         (value_argument
-          (simple_identifier)
+          (value_argument_label
+            (simple_identifier))
           (simple_identifier))))))
 
 ================================================================================

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -267,7 +267,8 @@ let e = array[...]
       (call_suffix
         (value_arguments
           (value_argument
-            (simple_identifier)
+            (value_argument_label
+              (simple_identifier))
             (simple_identifier))))))
   (property_declaration
     (pattern
@@ -279,7 +280,8 @@ let e = array[...]
           (value_argument
             (simple_identifier))
           (value_argument
-            (simple_identifier)
+            (value_argument_label
+              (simple_identifier))
             (simple_identifier))))))
   (property_declaration
     (pattern
@@ -526,7 +528,7 @@ modifyThis(&this)
 Selectors
 ================================================================================
 
-let selector = #selector(self.foo(parameter:))
+let selector = #selector(self.foo(parameter: param))
 let getterSelector = #selector(getter: self.bar)
 let setterSelector = #selector(setter: self.bar)
 
@@ -545,7 +547,9 @@ let setterSelector = #selector(setter: self.bar)
         (call_suffix
           (value_arguments
             (value_argument
-              (simple_identifier)))))))
+              (value_argument_label
+               (simple_identifier))
+                  (simple_identifier)))))))
   (property_declaration
     (pattern
       (simple_identifier))
@@ -567,7 +571,7 @@ let setterSelector = #selector(setter: self.bar)
 Function references
 ================================================================================
 
-self.foo(parameter:)
+self.foo(parameter: param)
 
 --------------------------------------------------------------------------------
 
@@ -580,7 +584,9 @@ self.foo(parameter:)
     (call_suffix
       (value_arguments
         (value_argument
-          (simple_identifier))))))
+          (value_argument_label
+            (simple_identifier))
+              (simple_identifier))))))
 
 ================================================================================
 Complex ternary expression
@@ -639,7 +645,8 @@ string[..<string.index(before: string.endIndex)]
               (call_suffix
                 (value_arguments
                   (value_argument
-                    (simple_identifier)
+                    (value_argument_label
+                          (simple_identifier))
                     (navigation_expression
                       (simple_identifier)
                       (navigation_suffix
@@ -730,19 +737,20 @@ Image.url(url, isLoaded: $done)
 
 --------------------------------------------------------------------------------
 
-(source_file
-  (call_expression
-    (navigation_expression
-      (simple_identifier)
-      (navigation_suffix
-        (simple_identifier)))
-    (call_suffix
-      (value_arguments
-        (value_argument
-          (simple_identifier))
-        (value_argument
+    (source_file
+      (call_expression
+        (navigation_expression
           (simple_identifier)
-          (simple_identifier))))))
+          (navigation_suffix
+            (simple_identifier)))
+        (call_suffix
+          (value_arguments
+            (value_argument
+              (simple_identifier))
+            (value_argument
+              (value_argument_label
+                (simple_identifier))
+                (simple_identifier))))))
 
 ================================================================================
 Key-path expressions
@@ -780,7 +788,8 @@ let keyPathStringExpression = #keyPath(someProperty)
       (call_suffix
         (value_arguments
           (value_argument
-            (simple_identifier)
+            (value_argument_label
+              (simple_identifier))
             (integer_literal))))))
   (call_expression
     (navigation_expression
@@ -809,7 +818,8 @@ let keyPathStringExpression = #keyPath(someProperty)
         (call_suffix
           (value_arguments
             (value_argument
-              (simple_identifier)
+              (value_argument_label
+                  (simple_identifier))
               (navigation_expression
                 (key_path_expression)
                 (navigation_suffix
@@ -850,7 +860,8 @@ trimPathAtLengths(positions: [(start: start, end: end)])
     (call_suffix
       (value_arguments
         (value_argument
-          (simple_identifier)
+          (value_argument_label
+            (simple_identifier))
           (array_literal
             (tuple_expression
               (simple_identifier)
@@ -1130,13 +1141,16 @@ async(async: async, qos: qos, flags: flags) {
     (call_suffix
       (value_arguments
         (value_argument
-          (simple_identifier)
+          (value_argument_label
+            (simple_identifier))
           (simple_identifier))
         (value_argument
-          (simple_identifier)
+          (value_argument_label
+            (simple_identifier))
           (simple_identifier))
         (value_argument
-          (simple_identifier)
+          (value_argument_label
+            (simple_identifier))
           (simple_identifier)))
       (lambda_literal
         (statements

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -158,7 +158,8 @@ sum(1, with: 2)
         (value_argument
           (integer_literal))
         (value_argument
-          (simple_identifier)
+          (value_argument_label
+            (simple_identifier))
           (integer_literal))))))
 
 ================================================================================
@@ -616,7 +617,8 @@ test(block: ===)
     (call_suffix
       (value_arguments
         (value_argument
-          (simple_identifier))))))
+          (value_argument_label
+           (simple_identifier)))))))
 
 ================================================================================
 Higher-order functions - pt 8

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -93,7 +93,8 @@ Custom interpolation
   (line_string_literal
     (line_str_text)
     (interpolated_expression
-      (simple_identifier)
+      (value_argument_label
+        (simple_identifier))
       (simple_identifier))))
 
 ================================================================================
@@ -730,7 +731,8 @@ doOperation(on: a, /)
     (call_suffix
       (value_arguments
         (value_argument
-          (simple_identifier)
+          (value_argument_label
+            (simple_identifier))
           (simple_identifier))
         (value_argument))))
   (comment))


### PR DESCRIPTION
This PR fixes:
* Argument Label for swift when used inside function calls as arguments. This aims to separate it from the time of creation or function declaration. 